### PR TITLE
Added shim support for mb --autoclass

### DIFF
--- a/gslib/commands/mb.py
+++ b/gslib/commands/mb.py
@@ -238,6 +238,8 @@ class MbCommand(Command):
   gcloud_storage_map = GcloudStorageMap(
       gcloud_command=['storage', 'buckets', 'create'],
       flag_map={
+          '--autoclass':
+              GcloudStorageFlag('--enable-autoclass'),
           '-b':
               GcloudStorageFlag({
                   'on': '--uniform-bucket-level-access',


### PR DESCRIPTION
Included following tests:
- Test for shim translation of --autoclass flag.
- Integration(e2e) tests for --autoclass flag, to support parity tests.